### PR TITLE
Validate that interfaces should not have any resolver

### DIFF
--- a/src/tools/graphql/api.clj
+++ b/src/tools/graphql/api.clj
@@ -116,5 +116,7 @@
       (pcompose [:red "Unreachable input"] " " (name f) (print-loc loc)))
     (doseq [[i loc] (validators/unreachable-interfaces schema)]
       (pcompose [:red "Unreachable interface"] " " (name i) (print-loc loc)))
+    (doseq [[i _loc field] (validators/interface-with-resolver schema)]
+      (pcompose [:red "Interface should not have resolvers"] " " (name i) "." (name field)))
     (doseq [m (validators/relay-arguments schema)]
       (pcompose [:red "Invalid pagination arguments"] " " (name (:query m)) [:blue " " (:hint m)]))))

--- a/src/tools/graphql/stitch/core.clj
+++ b/src/tools/graphql/stitch/core.clj
@@ -54,6 +54,7 @@
       (update :objects dissoc :Query :Mutation :Subscription)))
 
 (defn source-map
+  "TODO: only support for 1-level map"
   [path]
   (fn [schema]
     (let [embed-loc #(update-vals % (fn [v]

--- a/src/tools/graphql/validators.clj
+++ b/src/tools/graphql/validators.clj
@@ -160,21 +160,27 @@
 (defn interface-with-resolver
   [schema]
   (sort (m/search schema
-                  {:interfaces {?ifc {:loc    ?loc
-                                      :fields {?field {:resolver (m/some ?resolver)}}}}}
+                  {:interfaces {?ifc {:fields {?field {:resolve (m/some ?resolver)
+                                                       :loc     ?loc}}}}}
                   [?ifc ?loc ?field ?resolver])))
 
 (comment
 
   (require '[tools.graphql.stitch.core :refer [read-edn]]
            '[clojure.java.io :as io])
-  (def schema (read-edn (io/file "../farmmorning-backend/bases/core-api/resources/superschema.edn")))
+  @(def schema (read-edn (io/file "../farmmorning-backend/bases/core-api/resources/superschema.edn")))
   (def schema (read-edn (io/resource "unreachable.edn")))
   (def schema (read-edn (io/resource "pagination.edn")))
 
   (unreachable-types schema)
   (unreachable-input-types schema)
   (unreachable-interfaces schema)
+  (interface-with-resolver schema)
+
+  (m/search schema
+            {:interfaces {?ifc {:loc    ?loc
+                                :fields {?field {:resolve ?resolver}}}}}
+            [?ifc ?loc ?field ?resolver])
 
   (no-root-resolver schema)
   (relay-arguments schema)

--- a/src/tools/graphql/validators.clj
+++ b/src/tools/graphql/validators.clj
@@ -157,10 +157,13 @@
                            "A field that returns a Connection Type must include forward pagination arguments, backward pagination arguments, or both.")]
                 (assoc m :hint hint))))))
 
-(guess-connection-direction {:first          {:type '(non-null Int)},
-                             :after          {:type 'ID},
-                             :orderBy        {:type :CommunityPostCommentOrderBy, :default-value :CREATED_AT},
-                             :orderDirection {:type :OrderDirection, :default-value :DESC}})
+(defn interface-with-resolver
+  [schema]
+  (sort (m/search schema
+                  {:interfaces {?ifc {:loc    ?loc
+                                      :fields {?field {:resolver (m/some ?resolver)}}}}}
+                  [?ifc ?loc ?field ?resolver])))
+
 (comment
 
   (require '[tools.graphql.stitch.core :refer [read-edn]]
@@ -175,5 +178,10 @@
 
   (no-root-resolver schema)
   (relay-arguments schema)
+
+  (guess-connection-direction {:first          {:type '(non-null Int)},
+                               :after          {:type 'ID},
+                               :orderBy        {:type :CommunityPostCommentOrderBy, :default-value :CREATED_AT},
+                               :orderDirection {:type :OrderDirection, :default-value :DESC}})
 
   :rcf)

--- a/test/tools/graphql/validators_test.clj
+++ b/test/tools/graphql/validators_test.clj
@@ -74,6 +74,25 @@
                                :Dummy   {:fields {:id {:type 'String}}}}}]
       (is (= [[:UnusedIf nil]] (v/unreachable-interfaces schema))))))
 
+(deftest interface-with-resolver-test
+  (testing "interface should not have any resolvers to its fields"
+    (let [schema {:interfaces {:Node {:fields {:id {:type        '(non-null ID)
+                                                    :description "The id of the object"}}}
+                               :Post {:implements [:Node]
+                                      :fields     {:id     {:type        '(non-null ID)
+                                                            :description "The id of the object"}
+                                                   :title  {:type        '(non-null String)
+                                                            :description "The title of the post"
+                                                            :resolver    (fn [_ _ _] nil)}
+                                                   :author {:type        '(non-null User)
+                                                            :description "The author of the post"}}}}}
+          result (v/interface-with-resolver schema)]
+      (is (= (count result) 1))
+      (is (let [[ifc _ field resolver] (first result)]
+            (and (= ifc :Post)
+                 (= field :title)
+                 (some? resolver)))))))
+
 (deftest no-root-resolver
   (testing "query or mutation without resolver"
     (let [schema {:queries   {:user {:type :User}}

--- a/test/tools/graphql/validators_test.clj
+++ b/test/tools/graphql/validators_test.clj
@@ -83,7 +83,7 @@
                                                             :description "The id of the object"}
                                                    :title  {:type        '(non-null String)
                                                             :description "The title of the post"
-                                                            :resolver    (fn [_ _ _] nil)}
+                                                            :resolve     (fn [_ _ _] nil)}
                                                    :author {:type        '(non-null User)
                                                             :description "The author of the post"}}}}}
           result (v/interface-with-resolver schema)]


### PR DESCRIPTION
https://github.com/green-labs/farmmorning-backend/issues/6985#issuecomment-2288101982

sample output:

```
Interface should not have resolvers FeedItemV2.reason
Interface should not have resolvers Post.actionLink
Interface should not have resolvers Post.author
Interface should not have resolvers Post.commentsCount
Interface should not have resolvers Post.communityPostComments
Interface should not have resolvers Post.createdAt
Interface should not have resolvers Post.imagesV2
Interface should not have resolvers Post.isBlocked
Interface should not have resolvers Post.isDeleted
Interface should not have resolvers Post.isMine
Interface should not have resolvers Post.likers
Interface should not have resolvers Post.popularPostComment
Interface should not have resolvers Post.readCount
Interface should not have resolvers Post.recentPostComment
Interface should not have resolvers Post.urlPreviews
Interface should not have resolvers Post.userBookmarked
Interface should not have resolvers Post.userLiked
```