### PR TITLE
Handle SDL conversion for enums that are not specified as a map

### DIFF
--- a/src/tools/graphql/sdl.clj
+++ b/src/tools/graphql/sdl.clj
@@ -105,12 +105,14 @@
          (str (->doc description)
               "enum " (name k) " {\n"
               (->> values
-                   (map (fn [{:keys [description deprecated enum-value]}]
-                          (str
-                           (->doc description "  ")
-                           "  "
-                           (name enum-value)
-                           (when deprecated (str " " (->deprecated deprecated))))))
+                   (map (fn [{:keys [description deprecated enum-value] :as value}]
+                          (if (keyword? value)
+                            (str "  " (name value))
+                            (str
+                             (->doc description "  ")
+                             "  "
+                             (name enum-value)
+                             (when deprecated (str " " (->deprecated deprecated)))))))
                    (s/join "\n"))
               "\n}\n"))
        (vec m)))

--- a/test-resources/sdl/enum-simple.edn
+++ b/test-resources/sdl/enum-simple.edn
@@ -1,0 +1,3 @@
+{:enums {:OrderDirection {:description "Order Direction"
+                          :values      [:ASC :DESC]}
+         :Role           {:values [:USER :MANAGER :ADMIN]}}}

--- a/test-resources/sdl/enum-simple.graphql
+++ b/test-resources/sdl/enum-simple.graphql
@@ -1,0 +1,13 @@
+"""
+Order Direction
+"""
+enum OrderDirection {
+  ASC
+  DESC
+}
+
+enum Role {
+  USER
+  MANAGER
+  ADMIN
+}

--- a/test/tools/graphql/sdl_test.clj
+++ b/test/tools/graphql/sdl_test.clj
@@ -19,6 +19,7 @@
                           (let [[a b _] (diff-edn-sdl filename)]
                             (is (= a b nil))))]
     (test-conversion "enum")
+    (test-conversion "enum-simple")
     (test-conversion "interface")
     (test-conversion "object")
     (test-conversion "query")
@@ -28,5 +29,4 @@
     (test-conversion "scalar")))
 
 (comment
-  (run-tests)
-  )
+  (run-tests))


### PR DESCRIPTION
The library expects enums to be specified in the following format:
```clojure
{:enums
 {:Episode
  {:description "The episodes of the original Star Wars trilogy."
   :values [{:enum-value :NEWHOPE :description "The first one you saw."}
            {:enum-value :EMPIRE :description "The good one."}
            {:enum-value :JEDI :description "The one with the killer teddy bears."}]}}}
```
but a simpler format is also valid (https://lacinia.readthedocs.io/en/stable/enums.html)
```clojure
{:enums
 {:Episode
  {:description "The episodes of the original Star Wars trilogy."
   :values [:NEWHOPE :EMPIRE :JEDI]}}}
```
This PR handles the simple case.