### PR TITLE
emit superschema in modern syntax

### DIFF
--- a/src/tools/graphql/api.clj
+++ b/src/tools/graphql/api.clj
@@ -38,7 +38,7 @@
                                                          :source-map?  source-map?})
         _           (when-not (seq subschemas)
                       (throw (ex-info "No subschemas found" {})))
-        superschema (reduce stitch/stitch-subschemas subschemas)]
+        superschema (stitch/make-superschema subschemas)]
     (if output-path
       (let [output-file (coerce-to-file output-path "superschema.edn")]
         (when (some #(is-path-under-dir? output-path %) input-paths)

--- a/src/tools/graphql/stitch/core.clj
+++ b/src/tools/graphql/stitch/core.clj
@@ -18,7 +18,7 @@
 (def ^:dynamic *modern-syntax?* true)
 
 (defn- validate-subschema!
-  [^Subschema {:keys [name path contents]}]
+  [^Subschema {:keys [path contents]}]
   (when *modern-syntax?*
     (let [{:keys [queries mutations]} contents]
       (when (or (seq queries) (seq mutations))
@@ -140,7 +140,7 @@
     (map->Subschema {:contents res})))
 
 (defn make-superschema
-  [subschemas]
+  ^Subschema [subschemas]
   (let [superschema (reduce stitch-subschemas subschemas)]
     ;; apply post transformers
     (cond-> superschema
@@ -157,15 +157,11 @@
   (read-subschema (io/file "test-resources/subschemas/user.edn"))
   (def subschemas (read-subschemas ["test-resources/subschemas"]))
 
-  (let [whole (reduce stitch-subschemas subschemas)]
-    (time (print-schema whole :pretty false)))
+  (reduce stitch-subschemas subschemas)
 
   (let [super (make-superschema subschemas)]
     (print-schema super :pretty true))
 
   (validate-subschema!)
-
-  (let [schema (read-subschema (io/file "test-resources/subschemas/cart.edn") :source-map? true)]
-    schema)
 
   :rcf)

--- a/src/tools/graphql/stitch/core.clj
+++ b/src/tools/graphql/stitch/core.clj
@@ -5,10 +5,10 @@
   the-guild.dev 에서 stitch 라고 부르는 개념입니다.
   https://the-guild.dev/graphql/stitching
   "
-  (:require [clojure.edn :as edn]
+  (:require [clj-commons.ansi :refer [perr]]
+            [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.set :as set]
-            [clojure.tools.logging :as log]
             [edamame.core :as eda]
             [fipp.edn :refer [pprint]])
   (:import (java.io File PushbackReader)))
@@ -18,11 +18,13 @@
 (def ^:dynamic *modern-syntax?* true)
 
 (defn- validate-subschema!
-  [^Subschema {:keys [path contents]}]
+  [^Subschema {:keys [name path contents]}]
   (when *modern-syntax?*
     (let [{:keys [queries mutations]} contents]
       (when (or (seq queries) (seq mutations))
-        (log/warn ":queries and :mutations keys are deprecated." (str "(" path ")"))))))
+        (perr [:red ":queries and :mutations keys are deprecated."]
+              " "
+              [:blue path])))))
 
 (defn read-edn
   "schema 스펙 확장을 지원하는 edn 리더"
@@ -43,7 +45,13 @@
     (assoc m k v)
     m))
 
-(defn normalize-root-objects
+(defn- assoc-in-when
+  [m ks v]
+  (if v
+    (assoc-in m ks v)
+    m))
+
+(defn- demodernize
   "Reserved names for top-level objects in Lacinia are Query, Mutation, Subscription.
   Bring them up to :queries, :mutations and :subscriptions keys. (old notation)"
   [schema]
@@ -52,6 +60,20 @@
       (assoc-when :mutations (get-in schema [:objects :Mutation :fields]))
       (assoc-when :subscriptions (get-in schema [:objects :Subscription :fields]))
       (update :objects dissoc :Query :Mutation :Subscription)))
+
+(defn- modernize
+  "
+  args:
+    schema - plain map of whole schema
+  "
+  [^Subschema {:keys [contents] :as schema}]
+  (let [{:keys [queries mutations subscriptions]} contents
+        new-contents (-> contents
+                         (assoc-in-when [:objects :Query :fields] queries)
+                         (assoc-in-when [:objects :Mutation :fields] mutations)
+                         (assoc-in-when [:objects :Subscription :fields] subscriptions)
+                         (dissoc :queries :mutations :subscriptions))]
+    (assoc schema :contents new-contents)))
 
 (defn source-map
   "TODO: only support for 1-level map"
@@ -70,9 +92,9 @@
     path - path to read the subschema
     opts:
       :transformers - a list of functions to transform the schema before stitching."
+  ^Subschema
   [^File path & {:keys [source-map? transformers]}]
-  (let [contents    (cond-> (read-edn path source-map?)
-                            *modern-syntax?* normalize-root-objects
+  (let [contents    (cond-> (demodernize (read-edn path source-map?))
                             source-map? ((source-map (.getPath path))))
 
         ;; transform
@@ -99,11 +121,12 @@
   [a b]
   (set/intersection (set (keys a)) (set (keys b))))
 
-(def empty-subschema (map->Subschema {:contents {}}))
+;(def empty-subschema (map->Subschema {:contents {}}))
 
 (defn stitch-subschemas
   "Merge two subschemas into one subschema. If there is a conflict, throw an exception."
-  [{a :contents} {b :contents :as subschema-b}]
+  [^Subschema {a :contents}
+   ^Subschema {b :contents :as subschema-b}]
   (let [res (merge-with merge a b)
         _   (when-not (= (merge-with + (update-vals a count) (update-vals b count))
                          (update-vals res count))
@@ -116,6 +139,13 @@
                                  :conflicts conflicts}))))]
     (map->Subschema {:contents res})))
 
+(defn make-superschema
+  [subschemas]
+  (let [superschema (reduce stitch-subschemas subschemas)]
+    ;; apply post transformers
+    (cond-> superschema
+            *modern-syntax?* modernize)))
+
 (defn print-schema
   [^Subschema schema & {:keys [pretty] :as _opts}]
   (if pretty
@@ -127,8 +157,11 @@
   (read-subschema (io/file "test-resources/subschemas/user.edn"))
   (def subschemas (read-subschemas ["test-resources/subschemas"]))
 
-  (let [whole (time (reduce stitch-subschemas subschemas))]
+  (let [whole (reduce stitch-subschemas subschemas)]
     (time (print-schema whole :pretty false)))
+
+  (let [super (make-superschema subschemas)]
+    (print-schema super :pretty true))
 
   (validate-subschema!)
 

--- a/src/tools/graphql/stitch/watch.clj
+++ b/src/tools/graphql/stitch/watch.clj
@@ -9,7 +9,7 @@
   [{:keys [output-file pretty]}]
   {:pre [(some? output-file)]}
   (let [schemas     (vals @path->schema)
-        superschema (reduce stitch/stitch-subschemas schemas)]
+        superschema (stitch/make-superschema schemas)]
     (time
       (spit output-file (with-out-str (stitch/print-schema superschema :pretty pretty))))))
 

--- a/test-resources/subschemas/seller.edn
+++ b/test-resources/subschemas/seller.edn
@@ -1,0 +1,46 @@
+{:queries {}
+
+ :mutations
+ {:refuseReceivedOrder
+  {:description "판매자 - 판매 거부 (전체): 판매자가 수신한 주문에 대해 판매를 거부한다."
+   :args        {:id {:type        (non-null ID)
+                      :description "주문 ID"}}
+   :type        (non-null :OrderSellerActionPayload)}}
+
+ :input-objects
+ {:UpdateOrderShippingGroupShippingNumberInput
+  {:fields {:shippingNumber      {:type        (non-null String)
+                                  :description "송장 번호"}
+            :shippingCompanyCode {:type        (non-null String)
+                                  :description "택배사 코드"}}}
+  :UpdateOrderShippingGroupShippingNumberWithIdInput
+  {:fields {:id                  {:type        (non-null ID)
+                                  :description "주문배송그룹 ID"}
+            :shippingNumber      {:type        (non-null String)
+                                  :description "송장 번호"}
+            :shippingCompanyCode {:type        (non-null String)
+                                  :description "택배사 코드"}}}}
+
+ :unions
+ {:OrderSellerActionPayload
+  {:members [:OrderSellerActionResult :NotFoundError :InvalidInputError :InvalidOrderStatusError :SellerUnauthorizedError]}
+  :OrderShippingGroupSellerActionPayload
+  {:members [:OrderShippingGroupSellerActionResult :NotFoundError :InvalidInputError :InvalidOrderShippingGroupStatusError :ShippingTrackingError]}
+  :OrderShippingGroupsSellerActionPayload
+  {:members [:OrderShippingGroupsSellerActionResult :NotFoundError :InvalidInputError :InvalidOrderShippingGroupStatusError :ShippingTrackingError]}
+  :OrderProductOptionSellerActionPayload
+  {:members [:OrderProductOptionSellerActionResult :NotFoundError :InvalidInputError :InvalidOrderProductOptionStatusError :ShippingTrackingError]}
+  :OrderProductOptionsSellerActionPayload
+  {:members [:OrderProductOptionsSellerActionResult :NotFoundError :InvalidInputError :InvalidOrderProductOptionStatusError :ShippingTrackingError]}}
+
+ :objects
+ {:Mutation {:fields {:refuseReceivedOrderShippingGroup
+                      {:description "판매자 - 판매 거부 (배송그룹): 판매자가 수신한 주문 중 특정 배송그룹에 대해 판매를 거부한다."
+                       :args        {:id {:type        (non-null ID)
+                                          :description "주문배송그룹 ID"}}
+                       :type        (non-null :OrderShippingGroupSellerActionPayload)}}}
+  :Query    {:fields {}}
+  :OrderSellerActionResult
+  {:fields {:order {:type (non-null :Order)}}}
+  :OrderShippingGroupSellerActionResult
+  {:fields {:orderShippingGroup {:type (non-null :OrderShippingGroup)}}}}} }

--- a/test-resources/subschemas/user.edn
+++ b/test-resources/subschemas/user.edn
@@ -1,0 +1,7 @@
+{:objects {:Me    {:implements  [:Node]
+                   :description "로그인된 사용자 자신의 정보"
+                   :fields      {:id     {:type (! ID)}
+                                 :userId {:type (! Int)}
+                                 :name   {:type String}}}
+           :Query {:fields {:me {:type        (! :Me)
+                                 :description "로그인된 사용자 자신의 정보를 조회한다"}}}}}


### PR DESCRIPTION
closes #15 


Before
```edn
{:objects {:User {...}
           ...
 :queries {:user {...}
           ...
 :mutations {:createUser {...}
             ...}
 ...}
```

After
```edn
{:objects  {:User {...}
            :Query {:fields {:user {...}
                             ...}}
            :Mutation {:fields {:createUser {...}
                                ...}}
 ...}
```