### PR TITLE
Fix validator tests to use modern format

### DIFF
--- a/test/tools/graphql/validators_test.clj
+++ b/test/tools/graphql/validators_test.clj
@@ -23,15 +23,15 @@
                                                :createdAt {:type 'String}
                                                :updatedAt {:type 'String}
                                                :deletedAt {:type :Date}}}
-                              :Date  {:fields {:year  {:type 'Int}
-                                               :month {:type 'Int}
-                                               :day   {:type 'Int}}}
-                              :Dummy {:fields {:id {:type 'String}}}}
-                  :queries   {:user  {:type :User}
-                              :users {:type '(non-null (list (non-null :User)))}}
-                  :mutations {:createUser {:type :User}
-                              :updateUser {:type :User}
-                              :deleteUser {:type :User}}}]
+                              :Date     {:fields {:year  {:type 'Int}
+                                                :month {:type 'Int}
+                                                :day   {:type 'Int}}}
+                              :Dummy    {:fields {:id {:type 'String}}}
+                              :Query    {:fields {:user  {:type :User}
+                                                  :users {:type '(non-null (list (non-null :User)))}}}
+                              :Mutation {:fields {:createUser {:type :User}
+                                                  :updateUser {:type :User}
+                                                  :deleteUser {:type :User}}}}}]
       (is (= [[:Dummy nil nil]] (v/unreachable-types schema)))))
 
   (testing "object referenced in union"
@@ -42,8 +42,8 @@
   (testing "ignoring option"
     (let [schema {:objects {:User  {:fields {:id {:type 'String}}}
                             :Dummy {:linters {:ignore true}
-                                    :fields  {:id {:type 'String}}}}
-                  :queries {:user {:type :User}}}]
+                                    :fields  {:id {:type 'String}}}
+                            :Query {:fields {:user {:type :User}}}}}]
       (is (= [] (v/unreachable-types schema))))))
 
 (deftest no-unreachable-input-types
@@ -52,10 +52,10 @@
                                                        :email    {:type 'String}
                                                        :password {:type 'String}}}
                                   :Dummy     {:fields {:id {:type 'String}}}}
-                  :queries       {:user  {:type :User}
-                                  :users {:type '(non-null (list (non-null :User)))}}
-                  :mutations     {:updateUser {:type :User
-                                               :args {:input {:type :UserInput}}}}}]
+                  :objects       {:Query    {:fields {:user  {:type :User}
+                                                          :users {:type '(non-null (list (non-null :User)))}}}
+                                  :Mutation {:fields {:updateUser {:type :User
+                                                                   :args {:input {:type :UserInput}}}}}}}]
       (is (= [[:Dummy nil]] (v/unreachable-input-types schema)))))
 
   (testing "input-object referenced in another input-object"
@@ -102,17 +102,17 @@
 
 (deftest no-root-resolver
   (testing "query or mutation without resolver"
-    (let [schema {:queries   {:user {:type :User}}
-                  :mutations {:createUser {:type :User}
-                              :updateUser {:type :User}
-                              :deleteUser {:type :User}}}]
+    (let [schema {:objects {:Query    {:fields {:user {:type :User}}}
+                            :Mutation {:fields {:createUser {:type :User}
+                                                :updateUser {:type :User}
+                                                :deleteUser {:type :User}}}}}]
       (is (= [:user :createUser :updateUser :deleteUser]
              (v/no-root-resolver schema)))))
 
   (testing "resolver is 'maybe' or nil assigned"
-    (let [schema {:queries {:q {:resolve clojure.core/identity}
-                            :r {:resolve nil}
-                            :s {}}}]
+    (let [schema {:objects {:Query {:fields {:q {:resolve clojure.core/identity}
+                                              :r {:resolve nil}
+                                              :s {}}}}}]
       (is (= [:r :s] (v/no-root-resolver schema))))))
 
 (deftest pagination-direction-test


### PR DESCRIPTION
## Problem
The validator tests were failing after commit 713ccaf ("fix validators for modern syntax"). This commit attempted to update the test cases to use legacy format (:queries and :mutations), but the validators actually expect schemas in modern format (:objects with :Query and :Mutation).

## Root Cause
- In PR #16, the superschema output was changed to use modern syntax (:objects containing :Query and :Mutation types)
- Commit 713ccaf mistakenly thought the tests needed to use legacy format (:queries, :mutations)
- However, the validators process schemas **after** the `demodernize` transformation
- The `demodernize` function converts legacy syntax (:queries/:mutations) to modern syntax (:objects with :Query/:Mutation)
- Therefore, validators expect modern format, and the tests should provide schemas in that format

## Solution
Fixed the tests to use modern format that validators actually expect. This aligns with the output of the `demodernize` transformation.

## Changes
- Updated `no-root-resolver` tests to use `:objects {:Query ...}` instead of `:queries`
- Updated `unreachable-types` tests to merge Query and Mutation into `:objects` map
- Updated `unreachable-input-types` tests similarly

## Why this approach is correct
The `demodernize` function in `stitch/core.clj` transforms legacy syntax (:queries/:mutations) to modern syntax (:objects with :Query/:Mutation) before validators run. This means validators will always receive modern format schemas, so the tests should match this expectation.

All tests now pass successfully.