### PR TITLE
feat: Add simplified directive syntax support

### DIFF
--- a/test-resources/sdl/directive-simplified.edn
+++ b/test-resources/sdl/directive-simplified.edn
@@ -1,0 +1,35 @@
+{:directive-defs
+ {:auth {:description "Authentication directive"
+         :locations #{:field-definition}
+         :args {:roles {:type (list :Role)}}}
+  
+  :deprecated {:description "Marks an element as deprecated"
+               :locations #{:field-definition :enum-value}
+               :args {:reason {:type String
+                               :default-value "No longer supported"}}}
+  
+  :tag {:description "Add a tag to an element"
+        :repeatable true
+        :locations #{:field-definition :object}
+        :args {:name {:type (non-null String)}}}
+  
+  :skip {:description "Skip this field or fragment"
+         :locations #{:field :fragment-spread :inline-fragment}}}
+
+ :enums
+ {:Role {:values [{:enum-value :ADMIN}
+                  {:enum-value :USER}]}}
+
+ :objects
+ {:User {:directives {:tag {:name "model"}}  ; explicit map
+         :fields {:name {:type String
+                         :directives {:tag [{:name "sensitive"} {:name "pii"}]}}  ; list of maps for repeatable
+                  :role {:type :Role
+                         :directives {:auth {:roles [:ADMIN :USER]}}}  ; complex args
+                  :oldField {:type String
+                             :deprecated "Use name instead"}}}}
+
+ :mutations
+ {:updateUser {:type :User
+               :args {:id {:type (non-null ID)}}
+               :directives {:auth {:roles [:ADMIN]}}}}}

--- a/test-resources/sdl/directive-simplified.edn
+++ b/test-resources/sdl/directive-simplified.edn
@@ -21,9 +21,13 @@
                   {:enum-value :USER}]}}
 
  :objects
- {:User {:directives {:tag {:name "model"}}  ; explicit map
+ {:User {:directives {:tag {:name "model"}}  ; single directive with args
          :fields {:name {:type String
-                         :directives {:tag [{:name "sensitive"} {:name "pii"}]}}  ; list of maps for repeatable
+                         :directives {:tag [{:name "sensitive"} 
+                                           {:name "pii"}
+                                           {}]}}  ; repeatable: with args, with args, no args
+                  :email {:type String
+                          :directives {:skip true}}  ; no args using true
                   :role {:type :Role
                          :directives {:auth {:roles [:ADMIN :USER]}}}  ; complex args
                   :oldField {:type String

--- a/test/tools/graphql/transformers_test.clj
+++ b/test/tools/graphql/transformers_test.clj
@@ -1,6 +1,6 @@
 (ns tools.graphql.transformers-test
   (:require [clojure.test :refer [deftest is testing run-tests]]
-            [tools.graphql.transformers :refer [relay-pagination]]))
+            [tools.graphql.transformers :refer [relay-pagination transform-directives]]))
 
 (deftest relay-pagination-test
   (testing "lacinia schema에서 정의한 Node implements 하나만 된 objects들에게 Graphql relay spec에 맞는 edges, connections를 추가해줍니다"
@@ -98,6 +98,46 @@
                                                                                       :count    {:type        '(non-null Int)
                                                                                                  :description "Number of edges"}}}})]
       (is (= result expected-result)))))
+
+(deftest transform-directives-test
+  (testing "간소화된 directive 문법을 lacinia 형식으로 변환"
+    (let [schema {:directive-defs 
+                  {:tag {:repeatable true
+                         :args {:name {:type '(non-null String)}}}
+                   :auth {:args {:roles {:type '(list :Role)}}}}
+                  :objects 
+                  {:User {:directives {:tag {:name "model"}}
+                          :fields {:name {:directives {:tag [{:name "sensitive"} {:name "pii"}]}}
+                                   :role {:directives {:auth {:roles [:ADMIN]}}}}}}}
+          result (transform-directives schema)
+          expected {:directive-defs 
+                    {:tag {:repeatable true
+                           :args {:name {:type '(non-null String)}}}
+                     :auth {:args {:roles {:type '(list :Role)}}}}
+                    :objects
+                    {:User {:directives [{:directive-type :tag
+                                          :directive-args {:name "model"}}]
+                            :fields {:name {:directives [{:directive-type :tag
+                                                          :directive-args {:name "sensitive"}}
+                                                         {:directive-type :tag
+                                                          :directive-args {:name "pii"}}]}
+                                     :role {:directives [{:directive-type :auth
+                                                          :directive-args {:roles [:ADMIN]}}]}}}}}]
+      (is (= result expected))))
+  
+  (testing "기존 lacinia 형식은 그대로 유지"
+    (let [schema {:directive-defs {:tag {:repeatable true}}
+                  :objects {:User {:directives [{:directive-type :tag
+                                                 :directive-args {:name "model"}}]}}}
+          result (transform-directives schema)]
+      (is (= result schema))))
+  
+  (testing "repeatable이 아닌 directive에서 리스트 사용시 오류 발생"
+    (let [schema {:directive-defs {:auth {:args {:roles {:type '(list :Role)}}}}
+                  :objects {:User {:directives {:auth [{:roles "role1"} {:roles "role2"}]}}}}]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                           #"Directive :auth is not repeatable"
+                           (transform-directives schema))))))
 
 (comment
   (run-tests))


### PR DESCRIPTION
## Summary
- Add transformer for more concise and clear GraphQL directive declarations
- Simplify verbose `{:directive-type :tag :directive-args {:name "model"}}` format to `{:tag {:name "model"}}`

## Changes
- Add `transform-directives` function to convert simplified syntax to lacinia-compatible format
- Express repeatable directives as list of maps: `{:tag [{:name "a"} {:name "b"}]}`
- Throw clear error messages when lists are used with non-repeatable directives
- Add comprehensive test cases

## Test plan
- [x] Unit tests added and passing
- [x] All existing tests pass
- [x] Validation logic tested for repeatable/non-repeatable directives